### PR TITLE
Include marker with ID 0 in board pose estimation

### DIFF
--- a/aruco_board_detect/src/aruco_detect/aruco_board_detect_node.cpp
+++ b/aruco_board_detect/src/aruco_detect/aruco_board_detect_node.cpp
@@ -275,12 +275,12 @@ void ArucoDetectNode::boardDetectionTimedCallback(const ros::TimerEvent&)
     {
         // By knowing the number of markers in the board, we can filter out from the estimation the ones whose
         // ID is not within bounds
-        // e.g. a 7x5 board has markers with ids ranging from 1 to 35
+        // e.g. a 7x5 board has markers with ids ranging from 0 to 34
         // Split the markers that belong to the board and the singles
 
         for (int detected_marker_idx = 0; detected_marker_idx < marker_ids.size(); detected_marker_idx++)
         {
-            if (marker_ids[detected_marker_idx] > 0 && marker_ids[detected_marker_idx] < board_description_.n_markers_x_ * board_description_.n_markers_y_)
+            if (marker_ids[detected_marker_idx] >= 0 && marker_ids[detected_marker_idx] < board_description_.n_markers_x_ * board_description_.n_markers_y_)
             {
                 // Marker belongs to board
 


### PR DESCRIPTION
Hi @fbottarel 

Thanks for this very nice ROS package!

I noticed that marker with ID 0 that is part of a `GridBoard` description is never shown as detected in the debug image.

Looking more closely, I saw that it is because this marker is not taken into account when estimating the board pose by the check `marker_ids[detected_marker_idx] > 0 `

There is also related issue in the code comments that states ```// e.g. a 7x5 board has markers with ids ranging from 1 to 35```

It should actually be ```// e.g. a 7x5 board has markers with ids ranging from 0 to 34``` as confirmed by the [OpenCV doc](https://docs.opencv.org/3.4/db/da9/tutorial_aruco_board_detection.html)

This PR addressed this issue.

